### PR TITLE
Better formatting for uncommitted changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,12 +95,7 @@ export function activate(context: vscode.ExtensionContext) {
           0
         );
 
-        const elapsed = relativeTimePassed(
-          Date.now(),
-          parseInt(fields["author-time"]) * 1000
-        );
-
-        const message = `${fields.author}, ${elapsed} • ${fields.summary}`;
+        const message = formatMessage(fields);
 
         const hoverMessage = Object.entries(fields)
           .map((entry) => `- **${entry[0]}**: \`${entry[1]}\``)
@@ -131,4 +126,17 @@ export function activate(context: vscode.ExtensionContext) {
   );
 }
 
-export function deactivate() {}
+function formatMessage(fields: Record<string, string>): string {
+  const isUncommitted = fields["author"] === "Not Committed Yet";
+  if (isUncommitted) {
+    return 'Not committed yet';
+  }
+  const elapsed = relativeTimePassed(
+    Date.now(),
+    parseInt(fields["author-time"]) * 1000
+  );
+
+  return `${fields.author}, ${elapsed} • ${fields.summary}`;
+}
+
+export function deactivate() { }


### PR DESCRIPTION
Replaces this stuff:
<img width="949" alt="image" src="https://github.com/carlthome/vscode-git-line-blame/assets/3961616/98ecadb5-e88c-455f-8aee-c85ee1bc18a8">

With this:
<img width="332" alt="image" src="https://github.com/carlthome/vscode-git-line-blame/assets/3961616/4fe62cf0-7b4a-4634-8be9-00efe9fa0453">
