### PR TITLE
Skip entire publish job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,10 +16,8 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16.x
       - run: npm install
@@ -29,21 +27,18 @@ jobs:
         if: runner.os != 'Linux'
 
   publish:
+    if: startsWith(github.ref, 'refs/tags/')
     needs: test
     environment:
       name: Visual Studio Marketplace
       url: https://marketplace.visualstudio.com/items?itemName=carlthome.git-line-blame
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16.x
       - run: npm install
-      - name: Publish
-        if: startsWith(github.ref, 'refs/tags/')
-        run: npm run deploy
+      - run: npm run deploy
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
Noticed in PRs that the "deployed to environment" UI stuff appears since only the publish step inside the publish job was skipped for non-tags. Maybe better to just skip the entire job.