### PR TITLE
Allow older versions of VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ xvfb-run -a npm test
 
 1. Update the version in `package.json` according to [semver](https://semver.org/) (e.g. `npm version minor` for a new feature).
 1. Update the `CHANGELOG.md` with the new version and changes.
+1. `git push --tags`
 1. Submit a new release by `gh release create v$(npm pkg get version | xargs)` and fill in the details.
 
 ## FAQ

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "20.x",
-        "@types/vscode": "^1.87.0",
+        "@types/vscode": "^1.78.0",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
         "@vscode/test-electron": "^2.3.9",
@@ -249,9 +249,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.87.0.tgz",
-      "integrity": "sha512-y3yYJV2esWr8LNjp3VNbSMWG7Y43jC8pCldG8YwiHGAQbsymkkMMt0aDT1xZIOFM2eFcNiUc+dJMx1+Z0UT8fg==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.0.tgz",
+      "integrity": "sha512-LJZIJpPvKJ0HVQDqfOy6W4sNKUBBwyDu1Bs8chHBZOe9MNuKTJtidgZ2bqjhmmWpUb0TIIqv47BFUcVmAsgaVA==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.6",
     "@types/node": "20.x",
-    "@types/vscode": "^1.87.0",
+    "@types/vscode": "^1.78.0",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
     "@vscode/test-electron": "^2.3.9",


### PR DESCRIPTION
Would be nice to not require the latest release of VS Code for this basic extension but the release workflow encountered a version mismatch: https://github.com/carlthome/vscode-git-line-blame/actions/runs/8507975206/job/23300817326#step:5:11