### PR TITLE
No hover message for uncommited or unsaved changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2024-04-01
+
+- Skip hover message for uncommitted and unsaved changes
+
 ## [0.7.1] - 2024-04-01
 
 - Lower required VS Code version to 1.78.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2024-04-01
+
+- Lower required VS Code version to 1.78.0
+
 ## [0.7.0] - 2024-04-01
 
 - Show author as "You" when line blame matches current git user

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-line-blame",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-line-blame",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-line-blame",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-line-blame",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Git Line Blame",
   "description": "Display inline information in the text editor about the latest commit that edited the currently selected line",
   "publisher": "carlthome",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "AGPL-3.0-only",
   "icon": "icon.png",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Git Line Blame",
   "description": "Display inline information in the text editor about the latest commit that edited the currently selected line",
   "publisher": "carlthome",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "license": "AGPL-3.0-only",
   "icon": "icon.png",
   "engines": {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -81,6 +81,14 @@ export function formatMessage(
 }
 
 export function formatHoverMessage(fields: Record<string, string>): string {
+  // Leave hover message empty if there is no commit.
+  const notCommitted = fields["author"] === "Not Committed Yet";
+  const notSaved = fields["author"] === "External file (--contents)";
+  if (notCommitted || notSaved) {
+    return "";
+  }
+
+  // Format the hover message by collecting commit information.
   const header = "| Key | Value |\n| :-- | :-- |\n";
   const message = Object.entries(fields)
     .map(([k, v]) => {


### PR DESCRIPTION
The hover message mostly contains exotic information and shows up too often when typing in the editor and moving around the mouse. Arguably it makes more sense to only have the hover message for actual git commits, so here we go.