### PR TITLE
Throttle showDecoration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,13 @@
       "name": "git-line-blame",
       "version": "0.8.0",
       "license": "AGPL-3.0-only",
+      "dependencies": {
+        "throttle-debounce": "^5.0.0"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "20.x",
+        "@types/throttle-debounce": "^5.0.2",
         "@types/vscode": "^1.78.0",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
@@ -246,6 +250,12 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true
+    },
+    "node_modules/@types/throttle-debounce": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+      "integrity": "sha512-pDzSNulqooSKvSNcksnV72nk8p7gRqN8As71Sp28nov1IgmPKWbOEIwAWvBME5pPTtaXJAvG3O4oc76HlQ4kqQ==",
       "dev": true
     },
     "node_modules/@types/vscode": {
@@ -3344,6 +3354,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/throttle-debounce": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+      "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==",
+      "engines": {
+        "node": ">=12.22"
+      }
     },
     "node_modules/tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,13 @@
     "test": "node ./out/test/runTest.js",
     "deploy": "vsce publish"
   },
+  "dependencies": {
+    "throttle-debounce": "^5.0.0"
+  },
   "devDependencies": {
     "@types/mocha": "^10.0.6",
     "@types/node": "20.x",
+    "@types/throttle-debounce": "^5.0.2",
     "@types/vscode": "^1.78.0",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as cp from "child_process";
+import { throttle } from "throttle-debounce";
 
 import {
   parseGitBlamePorcelain,
@@ -74,13 +75,14 @@ function showDecoration(e: { readonly textEditor: vscode.TextEditor }) {
 
 export function activate(context: vscode.ExtensionContext) {
   console.log('Extension "git-line-blame" has activated.');
+  let showDecorationThrottled = throttle(100, showDecoration);
   context.subscriptions.push(
-    vscode.window.onDidChangeTextEditorSelection(showDecoration),
-    vscode.window.onDidChangeTextEditorVisibleRanges(showDecoration),
+    vscode.window.onDidChangeTextEditorSelection(showDecorationThrottled),
+    vscode.window.onDidChangeTextEditorVisibleRanges(showDecorationThrottled),
     vscode.workspace.onDidSaveTextDocument((e) => {
       const editor = vscode.window.activeTextEditor;
       if (editor !== undefined && e === editor.document) {
-        showDecoration({ textEditor: editor });
+        showDecorationThrottled({ textEditor: editor });
       }
     })
   );


### PR DESCRIPTION
When moving the cursor up and down lines quickly, this extension executes git a lot of times and the line blame can't keep up. This adds a small 100ms throttle ensuring that git doesn't get called more than ten times per second. It should still be just as responsive for normal cursor movements.